### PR TITLE
fix E26, current build.sh run not enough memory.

### DIFF
--- a/GenerateToken/build.sh
+++ b/GenerateToken/build.sh
@@ -19,5 +19,5 @@ nitro-cli build-enclave --docker-uri generatetoken-demo:latest  --output-file Ge
 
 vsock-proxy 8000 kms.ap-northeast-1.amazonaws.com 443 &
 
-nitro-cli run-enclave --cpu-count 2 --memory 2900 --enclave-cid 10 --eif-path GenerateToken-demo.eif --debug-mode
+nitro-cli run-enclave --cpu-count 2 --memory 3072 --enclave-cid 10 --eif-path GenerateToken-demo.eif --debug-mode
 # nitro-cli console --enclave-id $(nitro-cli describe-enclaves | jq -r ".[0].EnclaveID")

--- a/SignVerify/build.sh
+++ b/SignVerify/build.sh
@@ -19,5 +19,5 @@ nitro-cli build-enclave --docker-uri signverify-demo:latest  --output-file SignV
 
 vsock-proxy 8000 kms.ap-northeast-1.amazonaws.com 443 &
 
-nitro-cli run-enclave --cpu-count 2 --memory 2900 --enclave-cid 10 --eif-path SignVerify-demo.eif --debug-mode
+nitro-cli run-enclave --cpu-count 2 --memory 3072 --enclave-cid 10 --eif-path SignVerify-demo.eif --debug-mode
 # nitro-cli console --enclave-id $(nitro-cli describe-enclaves | jq -r ".[0].EnclaveID")


### PR DESCRIPTION
[ E26 ] Insufficient memory requested. User provided `memory` is 2900 MB, but based on the EIF file size, the minimum memory should be 3016 MB